### PR TITLE
fix: if CSV does not exists and it is read

### DIFF
--- a/redbird/repos/csv.py
+++ b/redbird/repos/csv.py
@@ -106,6 +106,10 @@ class CSVFileRepo(TemplateRepo):
 
     def read_file(self) -> Iterator[dict]:
         "Read repository file"
+        if not self.filename.is_file():
+            # The repository does not exists, creating
+            self.create(if_exists="ignore")
+            return
         with open(self.filename, "r") as file:
             reader = self.get_reader(file)
 

--- a/redbird/test/repo/test_csv.py
+++ b/redbird/test/repo/test_csv.py
@@ -34,6 +34,12 @@ def test_none(tmpdir):
     repo.add(Item(id="b", name="John"))
     assert [Item(id="b", name="John", age=None)] == repo.filter_by().all()
 
+def test_none_read(tmpdir):
+    file = tmpdir / "test.csv"
+    repo = CSVFileRepo(filename=file, model=Item)
+
+    assert [] == repo.filter_by().all()
+
 def test_kwds_csv(tmpdir):
     file = tmpdir / "test.csv"
     repo = CSVFileRepo(filename=file, model=Item, kwds_csv={'delimiter': '|'})

--- a/redbird/test/repo/test_csv.py
+++ b/redbird/test/repo/test_csv.py
@@ -39,6 +39,14 @@ def test_none_read(tmpdir):
     repo = CSVFileRepo(filename=file, model=Item)
 
     assert [] == repo.filter_by().all()
+    assert repo.filename.read_text() == "id,name,age\n"
+
+def test_fieldnames_read(tmpdir):
+    file = tmpdir / "test.csv"
+    repo = CSVFileRepo(filename=file, fieldnames=["id", "name", "age"])
+
+    assert [] == repo.filter_by().all()
+    assert repo.filename.read_text() == "id,name,age\n"
 
 def test_kwds_csv(tmpdir):
     file = tmpdir / "test.csv"


### PR DESCRIPTION
Now the CSV is created instead of raising an error.

This does not throw error if the CSV file does not exists:

```python
from redbird.repos import CSVFileRepo

repo = CSVFileRepo(filename="myfile.csv", fieldnames=["name", "age", "color"])

repo.filter_by().all() # Previously gave an error
```
Instead, the file is created.