### PR TITLE
BUG: __id_field__ and create table types

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,6 +4,11 @@
 Version history
 ===============
 
+- ``0.6.1``
+
+    - SQL: fix model based ``__id_field__`` in reflection
+    - SQL: fix date-like types in table creation with ``if_missing='create'``
+
 - ``0.6.0``
 
     - Added alternative way to set repository's ID field: setting ``__id_field__`` in model

--- a/redbird/repos/sqlalchemy.py
+++ b/redbird/repos/sqlalchemy.py
@@ -193,7 +193,8 @@ class SQLRepo(TemplateRepo):
                 if if_missing == "raise":
                     raise NoSuchTableError(f"Table {table} is missing. Create the table or pass if_missing='create'")
                 elif if_missing == "create":
-                    self._create_table(session, kwargs['model'], name=table, primary_column=kwargs.get('id_field'))
+                    model = kwargs['model']
+                    self._create_table(session, model, name=table, primary_column=kwargs.get('id_field', getattr(model, "__id_field__", None)))
 
             self._Base = automap_base()
             self._Base.prepare(engine=engine, reflect=True)

--- a/redbird/repos/sqlalchemy.py
+++ b/redbird/repos/sqlalchemy.py
@@ -1,4 +1,4 @@
-
+import datetime
 from typing import TYPE_CHECKING, Any, Optional, Type
 from pydantic import BaseModel, Field, PrivateAttr
 from redbird import BaseRepo, BaseResult
@@ -320,15 +320,18 @@ class SQLRepo(TemplateRepo):
 
     def _create_table(self, session, model, name, primary_column=None):
         from sqlalchemy import Table, Column, MetaData
-        from sqlalchemy import String, Integer, Float, Boolean
+        from sqlalchemy import String, Integer, Float, Boolean, Date, DateTime, JSON
         types = {
             str: String,
             int: Integer,
             float: Float,
-            bool: Boolean
+            bool: Boolean,
+            datetime.date: Date,
+            datetime.datetime: DateTime,
+            dict: JSON
         }
         columns = [
-            Column(name, types[field.type_], primary_key=name == primary_column)
+            Column(name, types.get(field.type_, field.type_), primary_key=name == primary_column)
             for name, field in model.__fields__.items()
         ]
         meta = MetaData()

--- a/redbird/test/repo/test_sql.py
+++ b/redbird/test/repo/test_sql.py
@@ -1,4 +1,5 @@
 
+import datetime
 import pytest
 from redbird.repos import SQLRepo
 from pydantic import BaseModel
@@ -219,6 +220,42 @@ def test_init_reflect_model_id_field_in_model():
     repo.add(MyItem(name="Jack", age=20))
     obs = engine.execute("select * from mytable")
     assert list(obs) == [('Jack', 20)]
+
+def test_init_type():
+    pytest.importorskip("sqlalchemy")
+
+    class MyItem(BaseModel):
+        __id_field__ = "id"
+        id: str
+        name: str
+        age: int
+        birth_date: datetime.date
+        observed: datetime.datetime
+        meta: dict
+
+    from sqlalchemy import create_engine
+    engine = create_engine('sqlite://')
+    repo = SQLRepo(model=MyItem, engine=engine, table="mytable", if_missing="create", id_field="id")
+    
+    repo.add(MyItem(
+        id="a",
+        name="myname",
+        age=25,
+        birth_date=datetime.date(2000, 1, 1),
+        observed=datetime.datetime(2000, 1, 1, 12, 30, 00),
+        meta={"yes": "no"}
+    ))
+    obs = repo.filter_by().all()
+    assert obs == [
+        MyItem(
+            id="a",
+            name="myname",
+            age=5,
+            birth_date=datetime.date(2000, 1, 1),
+            observed=datetime.datetime(2000, 1, 1, 12, 30, 00),
+            meta={"yes": "no"}
+        )
+    ]
 
 def test_init_create_table():
     pytest.importorskip("sqlalchemy")

--- a/redbird/test/repo/test_sql.py
+++ b/redbird/test/repo/test_sql.py
@@ -250,7 +250,7 @@ def test_init_type():
         MyItem(
             id="a",
             name="myname",
-            age=5,
+            age=25,
             birth_date=datetime.date(2000, 1, 1),
             observed=datetime.datetime(2000, 1, 1, 12, 30, 00),
             meta={"yes": "no"}

--- a/redbird/test/repo/test_sql.py
+++ b/redbird/test/repo/test_sql.py
@@ -203,6 +203,23 @@ def test_init_reflect_model_without_primary_key():
     with pytest.raises(KeyError):
         repo = SQLRepo(model=MyItem, engine=engine, table="mytable")
 
+def test_init_reflect_model_id_field_in_model():
+    pytest.importorskip("sqlalchemy")
+    from sqlalchemy import create_engine
+    engine = create_engine('sqlite://')
+    class MyItem(BaseModel):
+        __id_field__ = "name"
+        name: str
+        age: int
+
+    repo = SQLRepo(model=MyItem, engine=engine, table="mytable", if_missing="create")
+    assert repo.id_field == "name"
+
+    # Make sure the __id_field__ is not in there
+    repo.add(MyItem(name="Jack", age=20))
+    obs = engine.execute("select * from mytable")
+    assert list(obs) == [('Jack', 20)]
+
 def test_init_create_table():
     pytest.importorskip("sqlalchemy")
     from sqlalchemy import create_engine


### PR DESCRIPTION
This PR fixes two bugs:
- SQLRepo reflection with __id_field__ in the model
- SQLRepo date-like types in table creation (if ``if_missing="create"``)