### PR TITLE
Tempo fix for v2 compatibility

### DIFF
--- a/redbird/base.py
+++ b/redbird/base.py
@@ -6,7 +6,7 @@ from typing import Any, ClassVar, Dict, Generator, Iterator, List, Mapping, Opti
 from dataclasses import dataclass
 import warnings
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from redbird.exc import ConversionWarning, DataToItemError, KeyFoundError, ItemToDataError, _handle_conversion_error
 from redbird.utils.case import to_case

--- a/redbird/repos/csv.py
+++ b/redbird/repos/csv.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union, TextIO
 
 import csv
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Field, PrivateAttr
 from redbird import BaseRepo, BaseResult
 from redbird.base import Data, Item
 from redbird.templates import TemplateRepo

--- a/redbird/repos/json.py
+++ b/redbird/repos/json.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union, TextIO
 
 import csv, json
 
-from pydantic import BaseModel, PrivateAttr
+from pydantic.v1 import BaseModel, PrivateAttr
 from redbird import BaseRepo, BaseResult
 from redbird.base import Data, Item
 from redbird.templates import TemplateRepo

--- a/redbird/repos/memory.py
+++ b/redbird/repos/memory.py
@@ -2,7 +2,7 @@
 from operator import getitem
 from typing import Any, Dict, List
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Field, PrivateAttr
 from redbird import BaseRepo, BaseResult
 from redbird.templates import TemplateRepo
 from redbird.exc import KeyFoundError

--- a/redbird/repos/mongo.py
+++ b/redbird/repos/mongo.py
@@ -2,7 +2,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic.v1 import BaseModel, Field, ValidationError
 
 from redbird.base import BaseResult, BaseRepo
 from redbird.exc import KeyFoundError

--- a/redbird/repos/rest.py
+++ b/redbird/repos/rest.py
@@ -2,7 +2,7 @@
 import urllib.parse as urlparse
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Field, PrivateAttr
 
 from redbird.packages import requests
 from redbird.oper import GreaterEqual, GreaterThan, LessEqual, LessThan, NotEqual, Operation

--- a/redbird/repos/sqlalchemy.py
+++ b/redbird/repos/sqlalchemy.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional, Type
 import typing
 import sys
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Field, PrivateAttr
 from redbird import BaseRepo, BaseResult
 from redbird.dummy import DummySession
 from redbird.templates import TemplateRepo

--- a/redbird/sql/expressions.py
+++ b/redbird/sql/expressions.py
@@ -10,7 +10,7 @@ import typing
 from redbird.oper import Between, In, Operation, skip
 from redbird.packages import sqlalchemy, import_exists
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 try:
@@ -707,7 +707,7 @@ class Table:
             for name, field in model.__fields__.items()
         ]
         self.create(sql_cols)
-  
+
     def execute(self, *args, **kwargs):
         """Execute SQL statement or raw SQL.
         

--- a/redbird/test/common/conftest.py
+++ b/redbird/test/common/conftest.py
@@ -17,7 +17,7 @@ from redbird.repos.memory import MemoryRepo
 from redbird.repos.mongo import MongoRepo
 from redbird.oper import greater_equal, greater_than, less_equal, less_than, not_equal
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 # ------------------------
 # TEST ITEMS

--- a/redbird/test/common/test_common.py
+++ b/redbird/test/common/test_common.py
@@ -16,7 +16,7 @@ from redbird.repos.memory import MemoryRepo
 from redbird.repos.mongo import MongoRepo
 from redbird.oper import in_, skip, between, greater_equal, greater_than, less_equal, less_than, not_equal
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 TEST_CASES = [

--- a/redbird/test/logging/test_handler.py
+++ b/redbird/test/logging/test_handler.py
@@ -1,7 +1,7 @@
 
 import logging
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 import pytest
 

--- a/redbird/test/repo/test_csv.py
+++ b/redbird/test/repo/test_csv.py
@@ -2,7 +2,7 @@
 from typing import Optional
 
 from redbird.repos import CSVFileRepo
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 class Item(BaseModel):
     id: str

--- a/redbird/test/repo/test_json.py
+++ b/redbird/test/repo/test_json.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 
 from redbird.repos import JSONDirectoryRepo
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 class Item(BaseModel):
     id: str

--- a/redbird/test/repo/test_mongo.py
+++ b/redbird/test/repo/test_mongo.py
@@ -4,7 +4,7 @@ from typing import Optional
 from redbird.repos import MongoRepo
 
 import pytest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 class Item(BaseModel):
     id: str

--- a/redbird/test/repo/test_sql.py
+++ b/redbird/test/repo/test_sql.py
@@ -4,7 +4,7 @@ import sys
 import typing
 import pytest
 from redbird.repos import SQLRepo
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 try:
     from typing import Literal

--- a/redbird/test/sql/test_create.py
+++ b/redbird/test/sql/test_create.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from datetime import date
 import pytest
 

--- a/redbird/test/test_creation.py
+++ b/redbird/test/test_creation.py
@@ -1,5 +1,5 @@
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 import pytest
 from redbird import BaseRepo, BaseResult
 from redbird.repos import MemoryRepo


### PR DESCRIPTION
There's another repo where I tried to support pydantic v2 instead of v1, but that's alot of work, so for now I think best solution would be to use v1 but in v2, this would make compatible for tools that are already based on v2.
