### PR TITLE
Pydantic v2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/_build/
 
 # Coverage
 cov_data/
+
+# custom
+test.py

--- a/docs/examples/cli.py
+++ b/docs/examples/cli.py
@@ -37,7 +37,7 @@ def delete_item(item_id):
 
 def add_model_to_parser(parser: argparse.ArgumentParser, model):
     "Add Pydantic model's attributes as arguments to the parser"
-    fields = model.__fields__
+    fields = model.model_fields
     for name, field in fields.items():
         parser.add_argument(
             f"--{name}", 

--- a/docs/repos/sql/sql-orm.rst
+++ b/docs/repos/sql/sql-orm.rst
@@ -54,7 +54,7 @@ Using ORM model:
     from redbird.repos import SQLRepo
 
     engine = create_engine('sqlite://')
-    repo = SQLRepo(model_orm=Car, engine=engine)
+    repo = SQLRepo(orm=Car, engine=engine)
 
 Using ORM model and reflect Pydantic Model:
 
@@ -74,7 +74,7 @@ Using ORM model and reflect Pydantic Model:
     from redbird.repos import SQLRepo
 
     engine = create_engine('sqlite://')
-    repo = SQLRepo(model_orm=Car, reflect_model=True, engine=engine)
+    repo = SQLRepo(orm=Car, reflect_model=True, engine=engine)
 
 Using ORM model and Pydantic Model:
 
@@ -100,7 +100,7 @@ Using ORM model and Pydantic Model:
     from redbird.repos import SQLRepo
 
     engine = create_engine('sqlite://')
-    repo = SQLRepo(model=Car, model_orm=CarORM, engine=engine)
+    repo = SQLRepo(model=Car, orm=CarORM, engine=engine)
 
 Usage
 -----

--- a/redbird/__init__.py
+++ b/redbird/__init__.py
@@ -8,5 +8,5 @@ except ImportError:
     __version__ = version = '0.0.0.UNKNOWN'
     __version_tuple__ = version_tuple = (0, 0, 0, 'UNKNOWN', '')
 
-def create_repo(model=None, model_orm=None, repo_name="MemoryRepo"):
-    registry[repo_name](model=model, model_orm=model_orm)
+def create_repo(model=None, orm=None, repo_name="MemoryRepo"):
+    registry[repo_name](model=model, orm=orm)

--- a/redbird/base.py
+++ b/redbird/base.py
@@ -6,7 +6,7 @@ from typing import Any, ClassVar, Dict, Generator, Iterator, List, Mapping, Opti
 from dataclasses import dataclass
 import warnings
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 from redbird.exc import ConversionWarning, DataToItemError, KeyFoundError, ItemToDataError, _handle_conversion_error
 from redbird.utils.case import to_case
@@ -111,7 +111,7 @@ class BaseResult(ABC):
     def format_query(self, query:dict) -> dict:
         "Turn the query to a form that's understandable by the underlying database"
         qry = self.repo.query_model(**query)
-        return qry.format(self.repo) if hasattr(qry, "format") else qry.dict()
+        return qry.format(self.repo) if hasattr(qry, "format") else qry.model_dump()
 
 class BaseRepo(ABC, BaseModel):
     """Abstract Repository
@@ -139,10 +139,14 @@ class BaseRepo(ABC, BaseModel):
         converting data to the item model from
         the repository. By default raise 
     """
+    model_config = ConfigDict(
+        extra="allow",
+        from_attributes=True
+    )
     cls_result: ClassVar[Type[BaseResult]]
 
     model: Type = dict
-    id_field: Optional[str]
+    id_field: Optional[str] = Field(default=None, validate_default=True)
     
     query_model: Optional[Type[BaseModel]] = BasicQuery
 
@@ -150,13 +154,13 @@ class BaseRepo(ABC, BaseModel):
     field_access: Literal['attr', 'key', 'infer'] = 'infer'
 
     # Attributes that specifies how the repo behaves
-    ordered: bool = Field(default=False, const=True)
+    ordered: bool = Field(default=False)
 
-    @validator('id_field', always=True)
+    @field_validator('id_field')
     def set_id_field(cls, value, values):
         if value is None:
             # Get id_field from model
-            mdl = values.get("model")
+            mdl = values.data.get("model")
             return getattr(mdl, "__id_field__", None)
         return value
 
@@ -289,7 +293,7 @@ class BaseRepo(ABC, BaseModel):
             return item
         elif isinstance(item, BaseModel):
             # Pydantic model
-            return item.dict(exclude_unset=exclude_unset)
+            return item.model_dump(exclude_unset=exclude_unset)
         else:
             return dict(**item)
 

--- a/redbird/repos/csv.py
+++ b/redbird/repos/csv.py
@@ -66,7 +66,7 @@ class CSVFileRepo(TemplateRepo):
     kwds_csv: dict = {}
 
     _session = PrivateAttr()
-    ordered: bool = Field(default=True, const=True)
+    ordered: bool = Field(default=True)
 
     def insert(self, item):
         file_non_zero = self.filename.exists() and self.filename.stat().st_size > 0
@@ -99,8 +99,8 @@ class CSVFileRepo(TemplateRepo):
         "Get headers of the CSV file (using the model)"
         if self.fieldnames is not None:
             return self.fieldnames
-        elif hasattr(self.model, "__fields__"):
-            return list(self.model.__fields__)
+        elif hasattr(self.model, "model_fields"):
+            return list(self.model.model_fields)
         else:
             raise TypeError("Cannot determine CSV headers")
 

--- a/redbird/repos/memory.py
+++ b/redbird/repos/memory.py
@@ -56,7 +56,7 @@ class MemoryRepo(TemplateRepo):
     #cls_result = MemoryResult
     collection: List[Any] = []
 
-    ordered: bool = Field(default=False, const=True)
+    ordered: bool = Field(default=False)
     _session = PrivateAttr()
     
     def insert(self, item):

--- a/redbird/repos/mongo.py
+++ b/redbird/repos/mongo.py
@@ -1,5 +1,5 @@
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, Type
 
 
 from pydantic import BaseModel, Field, ValidationError
@@ -134,8 +134,8 @@ class MongoRepo(TemplateRepo):
         repo = MongoRepo(client=MongoClient("mongodb://localhost:27017"))
     """
     # cls_result = MongoResult
-    default_id_field = "_id"
-    cls_session = MongoSession
+    default_id_field:str = "_id"
+    cls_session:Type = MongoSession
 
     __operators__ = {
         GreaterThan: "$gt",
@@ -149,7 +149,7 @@ class MongoRepo(TemplateRepo):
     database: Optional[str]
     collection: Optional[str]
 
-    ordered: bool = Field(default=True, const=True)
+    ordered: bool = Field(default=True)
 
     def __init__(self, *args, uri=None, client=None, session=None, **kwargs):
         if uri is not None:

--- a/redbird/repos/mongo.py
+++ b/redbird/repos/mongo.py
@@ -146,8 +146,8 @@ class MongoRepo(TemplateRepo):
         In: "$in",
     }
     session: Any
-    database: Optional[str]
-    collection: Optional[str]
+    database: Optional[str] = None
+    collection: Optional[str] = None
 
     ordered: bool = Field(default=True)
 

--- a/redbird/repos/rest.py
+++ b/redbird/repos/rest.py
@@ -84,7 +84,7 @@ class RESTRepo(TemplateRepo):
 
         repo = RESTRepo(url="http://example.com/api", url_params={"fields": "car_type,car_model,registration_number"})
     """
-    result: Optional[Union[str, Callable]]
+    result: Optional[Union[str, Callable]] = None
     url: str
     url_params: dict = {}
     headers: dict = {}

--- a/redbird/repos/rest.py
+++ b/redbird/repos/rest.py
@@ -91,7 +91,7 @@ class RESTRepo(TemplateRepo):
 
     _session = PrivateAttr()
 
-    ordered: bool = Field(default=False, const=True)
+    ordered: bool = Field(default=False)
 
     def insert(self, item):
         json = self.item_to_dict(item, exclude_unset=False)

--- a/redbird/repos/sqlalchemy.py
+++ b/redbird/repos/sqlalchemy.py
@@ -268,7 +268,7 @@ class SQLRepo(TemplateRepo):
             return item
         elif hasattr(item, "dict"):
             # Is pydantic
-            return item.dict(exclude_unset=exclude_unset)
+            return item.model_dump(exclude_unset=exclude_unset)
         else:
             d = vars(item)
             d.pop("_sa_instance_state", None)

--- a/redbird/repos/sqlalchemy.py
+++ b/redbird/repos/sqlalchemy.py
@@ -156,9 +156,9 @@ class SQLRepo(TemplateRepo):
         repo = SQLRepo(model=Car, orm=CarORM, engine=engine)
     """
 
-    orm: Optional[Any]
-    table: Optional[str]
-    session: Optional[Any]
+    orm: Optional[Any] = None
+    table: Optional[str] = None
+    session: Optional[Any] = None
     engine: Optional[Any] = None
     autocommit: bool = Field(default=True, description="Whether to automatically commit the writes (create, delete, update)")
 

--- a/redbird/repos/sqlalchemy.py
+++ b/redbird/repos/sqlalchemy.py
@@ -158,7 +158,7 @@ class SQLRepo(TemplateRepo):
 
     orm: Optional[Any]
     table: Optional[str]
-    session: Any
+    session: Optional[Any]
     engine: Optional[Any] = None
     autocommit: bool = Field(default=True, description="Whether to automatically commit the writes (create, delete, update)")
 
@@ -217,7 +217,7 @@ class SQLRepo(TemplateRepo):
                 raise KeyError(f"Cannot automap table '{table}'. Perhaps table missing primary key?") from exc
             kwargs["orm"] = orm
         if reflect_model:
-            kwargs["model"] = self.orm_model_to_pydantic(kwargs["rm"])
+            kwargs["model"] = self.orm_model_to_pydantic(kwargs["orm"])
         super().__init__(*args, session=session, **kwargs)
 
     def insert(self, item):
@@ -238,7 +238,9 @@ class SQLRepo(TemplateRepo):
 
     def data_to_item(self, item_orm):
         # Turn ORM item to Pydantic item
-        set_attrs = self.model.model_config.get("from_attributes", None)
+        set_attrs = None
+        if hasattr(self.model, "model_config"):
+            set_attrs = self.model.model_config.get("from_attributes", None)
         if set_attrs:
             # Use Pydantic methods
              return self.model.model_validate(item_orm)

--- a/redbird/repos/sqlalchemy.py
+++ b/redbird/repos/sqlalchemy.py
@@ -4,6 +4,7 @@ import typing
 import sys
 
 from pydantic import BaseModel, Field, PrivateAttr
+from pydantic.main import _object_setattr
 from redbird import BaseRepo, BaseResult
 from redbird.dummy import DummySession
 from redbird.templates import TemplateRepo
@@ -31,11 +32,11 @@ class SQLRepo(TemplateRepo):
     conn_string : str, optional
         Connection string to the database. 
         Pass either conn_string, engine or session if
-        model_orm is not defined.
+        orm is not defined.
     engine : sqlalchemy.engine.Engine, optional
         SQLAlchemy engine to connect the database. 
         Pass either conn_string, engine or session if
-        model_orm is not defined.
+        orm is not defined.
     model : Type
         Class of an item in the repository.
         Commonly dict or subclass of Pydantic
@@ -54,16 +55,16 @@ class SQLRepo(TemplateRepo):
         the item in case of validation error in 
         converting data to the item model from
         the repository. By default raise 
-    model_orm : Type of Base, optional
+    orm : Type of Base, optional
         Subclass of SQL Alchemy representation of the item.
         This is the class that is operated behind the scenes.
     table : str, optional
         Table name where the items lies. Should only be given
-        if no model_orm specified.
+        if no orm specified.
     session : sqlalchemy.orm.Session
         Connection session to the database.
         Pass either conn_string, engine or session if
-        model_orm is not defined.
+        orm is not defined.
 
     Examples
     --------
@@ -106,7 +107,7 @@ class SQLRepo(TemplateRepo):
         from redbird.repos import SQLRepo
 
         engine = create_engine('sqlite://')
-        repo = SQLRepo(model_orm=Car, engine=engine)
+        repo = SQLRepo(orm=Car, engine=engine)
 
     Using ORM model and reflect Pydantic Model:
 
@@ -126,7 +127,7 @@ class SQLRepo(TemplateRepo):
         from redbird.repos import SQLRepo
 
         engine = create_engine('sqlite://')
-        repo = SQLRepo(model_orm=Car, reflect_model=True, engine=engine)
+        repo = SQLRepo(orm=Car, reflect_model=True, engine=engine)
 
     Using ORM model and Pydantic Model:
 
@@ -152,17 +153,17 @@ class SQLRepo(TemplateRepo):
         from redbird.repos import SQLRepo
 
         engine = create_engine('sqlite://')
-        repo = SQLRepo(model=Car, model_orm=CarORM, engine=engine)
+        repo = SQLRepo(model=Car, orm=CarORM, engine=engine)
     """
 
-    model_orm: Optional[Any]
+    orm: Optional[Any]
     table: Optional[str]
     session: Any
-    engine: Optional[Any]
+    engine: Optional[Any] = None
     autocommit: bool = Field(default=True, description="Whether to automatically commit the writes (create, delete, update)")
 
-    ordered: bool = Field(default=True, const=True)
-    _Base = PrivateAttr()
+    ordered: bool = Field(default=True)
+    _Base: Any
 
     @classmethod
     @deprecated("Please use normal init instead.")
@@ -177,14 +178,20 @@ class SQLRepo(TemplateRepo):
 
     def __init__(self, *args, reflect_model=False, conn_string=None, engine=None, session=None, if_missing="raise", **kwargs):
 
+        # Pre-emptively initiate pydantic extra and private
+        # Allow for using _Base as private attribute before
+        # running super().__init__()
+        _object_setattr(self, "__pydantic_extra__", {})
+        _object_setattr(self, "__pydantic_private__", None)
+
         # Determine connection
         if conn_string is not None:
             engine = sqlalchemy.create_engine(conn_string)
         if engine is not None:
             session = self.create_scoped_session(engine)
 
-        # Create model_orm/model
-        if "model_orm" not in kwargs:
+        # Create orm/model
+        if "orm" not in kwargs:
             if session is None:
                 raise TypeError(
                     "Connection cannot be determined. "
@@ -205,12 +212,12 @@ class SQLRepo(TemplateRepo):
             self._Base = automap_base()
             self._Base.prepare(autoload_with=engine)
             try:
-                model_orm = self._Base.classes[table]
+                orm = self._Base.classes[table]
             except KeyError as exc:
                 raise KeyError(f"Cannot automap table '{table}'. Perhaps table missing primary key?") from exc
-            kwargs["model_orm"] = model_orm
+            kwargs["orm"] = orm
         if reflect_model:
-            kwargs["model"] = self.orm_model_to_pydantic(kwargs["model_orm"])
+            kwargs["model"] = self.orm_model_to_pydantic(kwargs["rm"])
         super().__init__(*args, session=session, **kwargs)
 
     def insert(self, item):
@@ -231,9 +238,10 @@ class SQLRepo(TemplateRepo):
 
     def data_to_item(self, item_orm):
         # Turn ORM item to Pydantic item
-        if hasattr(self.model, "from_orm") and self.model.Config.orm_mode:
+        set_attrs = self.model.model_config.get("from_attributes", None)
+        if set_attrs:
             # Use Pydantic methods
-             return self.model.from_orm(item_orm)
+             return self.model.model_validate(item_orm)
         else:
             # Turn ORM to model using mapping
             d = vars(item_orm)
@@ -242,7 +250,7 @@ class SQLRepo(TemplateRepo):
 
     def item_to_data(self, item:BaseModel):
         # Turn Pydantic item to ORM item
-        return self.model_orm(**self.item_to_dict(item, exclude_unset=False))
+        return self.orm(**self.item_to_dict(item, exclude_unset=False))
 
     def orm_model_to_pydantic(self, model):
         # Turn SQLAlchemy BaseModel to Pydantic BaseModel
@@ -266,7 +274,7 @@ class SQLRepo(TemplateRepo):
 
     def create(self):
         "Create the database and table"
-        self.model_orm.__table__.create(bind=self.session.bind)
+        self.orm.__table__.create(bind=self.session.bind)
 
     def query_data(self, query):
         for data in self._filter_orm(query):
@@ -292,10 +300,10 @@ class SQLRepo(TemplateRepo):
 
     def _filter_orm(self, query):
         session = self.session
-        return session.query(self.model_orm).filter(query)
+        return session.query(self.orm).filter(query)
 
     def format_query(self, oper: dict):
-        return to_expression(oper, table=self.model_orm)
+        return to_expression(oper, table=self.orm)
 
     def _create_table(self, session, model, name, primary_column=None):
         table = Table(bind=session.get_bind(), name=name)

--- a/redbird/sql/expressions.py
+++ b/redbird/sql/expressions.py
@@ -699,12 +699,12 @@ class Table:
         sql_cols = [
             sqlalchemy.Column(
                 name, 
-                self._to_sqlalchemy_type(field.type_), 
+                self._to_sqlalchemy_type(field.annotation), 
                 primary_key=name in primary_column if primary_column is not None else False, 
-                nullable=not field.required,
+                nullable=not field.is_required(),
                 default=field.default
             )
-            for name, field in model.__fields__.items()
+            for name, field in model.model_fields.items()
         ]
         self.create(sql_cols)
   

--- a/redbird/sql/expressions.py
+++ b/redbird/sql/expressions.py
@@ -590,6 +590,13 @@ class Table:
                     if arg is not none_type:
                         cls = arg
                         break
+                if typing.get_origin(cls) is Literal:
+                    nested_args = typing.get_args(cls)
+                    type_ = type(nested_args[0])
+                    for nested_arg in nested_args:
+                        if not isinstance(nested_arg, type_):
+                            raise TypeError(f"Literal Values are not same types: {str(cls)}. Cannot define SQL data type")
+                    cls = type_
             
             if origin is Literal:
                 type_ = type(args[0])

--- a/redbird/test/common/conftest.py
+++ b/redbird/test/common/conftest.py
@@ -223,7 +223,7 @@ def get_repo(type_, tmpdir, model=PydanticItem):
 
     elif type_ == "sql-orm":
         engine = create_engine('sqlite://')
-        repo = SQLRepo(model_orm=SQLItem, engine=engine, table="items", id_field="id")
+        repo = SQLRepo(orm=SQLItem, engine=engine, table="items", id_field="id")
         repo.create()
 
     elif type_ == "sql-expr":
@@ -233,7 +233,7 @@ def get_repo(type_, tmpdir, model=PydanticItem):
 
     elif type_ == "sql-pydantic-orm":
         engine = create_engine('sqlite://')
-        repo = SQLRepo(model=PydanticItemORM, model_orm=SQLItem, engine=engine, id_field="id")
+        repo = SQLRepo(model=PydanticItemORM, orm=SQLItem, engine=engine, id_field="id")
         SQLItem.__table__.create(bind=repo.session.bind)
 
     elif type_ == "mongo-mock":

--- a/redbird/test/common/conftest.py
+++ b/redbird/test/common/conftest.py
@@ -27,12 +27,12 @@ class PydanticItem(BaseModel):
     __colname__ = 'items'
     id: str
     name: str
-    age: Optional[int]
+    age: Optional[int] = None
 
 class PydanticItemORM(BaseModel):
     id: str
     name: str
-    age: Optional[int]
+    age: Optional[int] = None
     model_config = ConfigDict(
         from_attributes=True
     )

--- a/redbird/test/common/conftest.py
+++ b/redbird/test/common/conftest.py
@@ -17,7 +17,7 @@ from redbird.repos.memory import MemoryRepo
 from redbird.repos.mongo import MongoRepo
 from redbird.oper import greater_equal, greater_than, less_equal, less_than, not_equal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 # ------------------------
 # TEST ITEMS
@@ -33,8 +33,9 @@ class PydanticItemORM(BaseModel):
     id: str
     name: str
     age: Optional[int]
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(
+        from_attributes=True
+    )
 
 class MongoItem(BaseModel):
     __colname__ = 'items'

--- a/redbird/test/common/conftest.py
+++ b/redbird/test/common/conftest.py
@@ -123,12 +123,12 @@ class RESTMock:
     def get(self, request):
         params = self.get_params(request)
         data = self.repo.filter_by(**params).all()
-        data = [item.dict() for item in data]
+        data = [item.model_dump() for item in data]
         return (200, {"Content-Type": "application/json"}, json.dumps(data))
 
     def get_one(self, request):
         id = self.get_id(request)
-        data = self.repo[id].dict()
+        data = self.repo[id].model_dump()
         return (200, {"Content-Type": "application/json"}, json.dumps(data))
 
     def get_params(self, req):

--- a/redbird/test/common/test_common.py
+++ b/redbird/test/common/test_common.py
@@ -16,7 +16,7 @@ from redbird.repos.memory import MemoryRepo
 from redbird.repos.mongo import MongoRepo
 from redbird.oper import in_, skip, between, greater_equal, greater_than, less_equal, less_than, not_equal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 
 TEST_CASES = [
@@ -700,13 +700,13 @@ class TestMalformedData(RepoTests):
             id: str
             name: int
             age: int
-
+        
         self.populate(repo, [
-            {"id": "a", "name": 1, "age": 20},
+            {"id": "a", "name": "1", "age": 20},
             {"id": "b", "name": "Jack", "age": 20},
             {"id": "c", "name": "James", "age": 30},
-            {"id": "d", "name": 2, "age": 30},
-            {"id": "e", "name": 3, "age": 30},
+            {"id": "d", "name": "2", "age": 30},
+            {"id": "e", "name": "3", "age": 30},
         ])
         repo.model = MalformedItem
 
@@ -721,11 +721,11 @@ class TestMalformedData(RepoTests):
             age: int
 
         self.populate(repo, [
-            {"id": "a", "name": 1, "age": 20},
+            {"id": "a", "name": "1", "age": 20},
             {"id": "b", "name": "Jack", "age": 20},
             {"id": "c", "name": "James", "age": 30},
-            {"id": "d", "name": 2, "age": 30},
-            {"id": "e", "name": 3, "age": 30},
+            {"id": "d", "name": "2", "age": 30},
+            {"id": "e", "name": "3", "age": 30},
         ])
         repo.model = MalformedItem
         repo.errors_query = "warn"
@@ -741,11 +741,11 @@ class TestMalformedData(RepoTests):
             age: int
 
         self.populate(repo, [
-            {"id": "a", "name": 1, "age": 20},
+            {"id": "a", "name": "1", "age": 20},
             {"id": "b", "name": "Jack", "age": 20},
             {"id": "c", "name": "James", "age": 30},
-            {"id": "d", "name": 2, "age": 30},
-            {"id": "e", "name": 3, "age": 30},
+            {"id": "d", "name": "2", "age": 30},
+            {"id": "e", "name": "3", "age": 30},
         ])
         repo.model = MalformedItem
         repo.errors_query = "discard"

--- a/redbird/test/repo/test_csv.py
+++ b/redbird/test/repo/test_csv.py
@@ -1,5 +1,6 @@
 
 from typing import Optional
+from pathlib import Path
 
 from redbird.repos import CSVFileRepo
 from pydantic import BaseModel
@@ -7,9 +8,10 @@ from pydantic import BaseModel
 class Item(BaseModel):
     id: str
     name: str
-    age: Optional[int]
+    age: Optional[int] = None
 
 def test_filecontent(tmpdir):
+    
     file = tmpdir / "test.csv"
     repo = CSVFileRepo(filename=file, model=Item)
 

--- a/redbird/test/repo/test_csv.py
+++ b/redbird/test/repo/test_csv.py
@@ -1,6 +1,5 @@
 
 from typing import Optional
-from pathlib import Path
 
 from redbird.repos import CSVFileRepo
 from pydantic import BaseModel
@@ -10,9 +9,9 @@ class Item(BaseModel):
     name: str
     age: Optional[int] = None
 
-def test_filecontent(tmpdir):
+def test_filecontent(tmp_path):
     
-    file = tmpdir / "test.csv"
+    file = tmp_path / "test.csv"
     repo = CSVFileRepo(filename=file, model=Item)
 
     repo.add(Item(id="a", name="Jack", age=20))
@@ -30,28 +29,28 @@ def test_filecontent(tmpdir):
     repo.filter_by().delete()
     assert "id,name,age\n" == file.read_text(encoding="UTF-8")
 
-def test_none(tmpdir):
-    file = tmpdir / "test.csv"
+def test_none(tmp_path):
+    file = tmp_path / "test.csv"
     repo = CSVFileRepo(filename=file, model=Item)
     repo.add(Item(id="b", name="John"))
     assert [Item(id="b", name="John", age=None)] == repo.filter_by().all()
 
-def test_none_read(tmpdir):
-    file = tmpdir / "test.csv"
+def test_none_read(tmp_path):
+    file = tmp_path / "test.csv"
     repo = CSVFileRepo(filename=file, model=Item)
 
     assert [] == repo.filter_by().all()
     assert repo.filename.read_text() == "id,name,age\n"
 
-def test_fieldnames_read(tmpdir):
-    file = tmpdir / "test.csv"
+def test_fieldnames_read(tmp_path):
+    file = tmp_path / "test.csv"
     repo = CSVFileRepo(filename=file, fieldnames=["id", "name", "age"])
 
     assert [] == repo.filter_by().all()
     assert repo.filename.read_text() == "id,name,age\n"
 
-def test_kwds_csv(tmpdir):
-    file = tmpdir / "test.csv"
+def test_kwds_csv(tmp_path):
+    file = tmp_path / "test.csv"
     repo = CSVFileRepo(filename=file, model=Item, kwds_csv={'delimiter': '|'})
 
     repo.add(Item(id="a", name="Jack", age=20))
@@ -61,8 +60,8 @@ def test_kwds_csv(tmpdir):
 
     assert repo.filter_by().all() == [Item(id="a", name="Jack", age=20), Item(id="b", name="John")]
 
-def test_dict_operations(tmpdir):
-    file = tmpdir / "test.csv"
+def test_dict_operations(tmp_path):
+    file = tmp_path / "test.csv"
     repo = CSVFileRepo(filename=file, fieldnames=['id', 'name', 'age'])
 
     # Insert

--- a/redbird/test/repo/test_json.py
+++ b/redbird/test/repo/test_json.py
@@ -10,43 +10,43 @@ from pydantic import BaseModel
 class Item(BaseModel):
     id: str
     name: str
-    age: Optional[int]
+    age: Optional[int] = None
 
 def sort_items(items, repo, field="id"):
     return list(sorted(items, key=lambda x: repo.get_field_value(x, field)))
 
-def test_missing_id(tmpdir):
+def test_missing_id(tmp_path):
     with pytest.raises(ValueError):
-        repo = JSONDirectoryRepo(path=tmpdir, model=Item)
+        repo = JSONDirectoryRepo(path=tmp_path, model=Item)
 
-def test_filecontent(tmpdir):
-    repo = JSONDirectoryRepo(path=tmpdir, model=Item, id_field="id")
+def test_filecontent(tmp_path):
+    repo = JSONDirectoryRepo(path=tmp_path, model=Item, id_field="id")
 
     repo.add(Item(id="1111", name="Jack", age=20))
     repo.add(Item(id="2222", name="John"))
     repo.add(Item(id="3333", name="James", age=30))
 
-    content = (tmpdir / "1111.json").read_text(encoding="UTF-8")
+    content = (tmp_path / "1111.json").read_text(encoding="UTF-8")
     assert content == '{"id": "1111", "name": "Jack", "age": 20}'
 
     repo.filter_by(id="1111").update(age=40)
-    content = (tmpdir / "1111.json").read_text(encoding="UTF-8")
+    content = (tmp_path / "1111.json").read_text(encoding="UTF-8")
     assert content == '{"id": "1111", "name": "Jack", "age": 40}'
 
     repo.filter_by(id="2222").delete()
-    assert not (tmpdir / "2222.json").exists()
+    assert not (tmp_path / "2222.json").exists()
 
     repo.filter_by().delete()
-    assert not (tmpdir / "1111.json").exists()
-    assert not (tmpdir / "3333.json").exists()
+    assert not (tmp_path / "1111.json").exists()
+    assert not (tmp_path / "3333.json").exists()
 
 
-def test_kwds_json(tmpdir):
-    repo = JSONDirectoryRepo(path=tmpdir, model=Item, id_field="id", kwds_json_dump={'indent': 4, 'sort_keys': True})
+def test_kwds_json(tmp_path):
+    repo = JSONDirectoryRepo(path=tmp_path, model=Item, id_field="id", kwds_json_dump={'indent': 4, 'sort_keys': True})
 
     repo.add(Item(id="1111", name="Jack", age=20))
 
-    content = (tmpdir / "1111.json").read_text(encoding="UTF-8")
+    content = (tmp_path / "1111.json").read_text(encoding="UTF-8")
     assert content == dedent('''
     {
         "age": 20,
@@ -58,8 +58,8 @@ def test_kwds_json(tmpdir):
     # Testing reading
     assert repo['1111'] == Item(id="1111", name="Jack", age=20)
 
-def test_dict_operations(tmpdir):
-    repo = JSONDirectoryRepo(path=tmpdir, id_field="id")
+def test_dict_operations(tmp_path):
+    repo = JSONDirectoryRepo(path=tmp_path, id_field="id")
 
     # Insert
     repo.add(dict(id="a", name="Jack", age=20))

--- a/redbird/test/repo/test_mongo.py
+++ b/redbird/test/repo/test_mongo.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 class Item(BaseModel):
     id: str
     name: str
-    age: Optional[int]
+    age: Optional[int] = None
 
 
 class ItemWithCol(BaseModel):

--- a/redbird/test/repo/test_mongo.py
+++ b/redbird/test/repo/test_mongo.py
@@ -16,7 +16,7 @@ class ItemWithCol(BaseModel):
     __colname__ = 'items'
     id: str
     name: str
-    age: Optional[int]
+    age: Optional[int] = None
 
 def test_creation_defaults():
     pytest.importorskip("pymongo")

--- a/redbird/test/repo/test_sql.py
+++ b/redbird/test/repo/test_sql.py
@@ -60,8 +60,8 @@ def test_init_engine():
         engine=engine
     )
     repo = SQLRepo(engine=engine, table="pytest")
-    assert repo.model_orm.__table__.name == "pytest"
-    assert all(hasattr(repo.model_orm, col) for col in ("id", "name", "age"))
+    assert repo.orm.__table__.name == "pytest"
+    assert all(hasattr(repo.orm, col) for col in ("id", "name", "age"))
 
     repo.add({"id": "a", "name": "Jack", "age": 500})
     assert list(repo) == [dict(id="a", name="Jack", age=500)]
@@ -82,8 +82,8 @@ def test_init_conn_string(tmpdir):
             engine=engine
         )
         repo = SQLRepo(conn_string=conn_string, table="pytest")
-        assert repo.model_orm.__table__.name == "pytest"
-        assert all(hasattr(repo.model_orm, col) for col in ("id", "name", "age"))
+        assert repo.orm.__table__.name == "pytest"
+        assert all(hasattr(repo.orm, col) for col in ("id", "name", "age"))
 
         repo.add({"id": "a", "name": "Jack", "age": 500})
         assert list(repo) == [dict(id="a", name="Jack", age=500)]
@@ -100,8 +100,8 @@ def test_init_session():
         age INTEGER
     )""", engine=engine)
     repo = SQLRepo(session=session, table="pytest")
-    assert repo.model_orm.__table__.name == "pytest"
-    assert all(hasattr(repo.model_orm, col) for col in ("id", "name", "age"))
+    assert repo.orm.__table__.name == "pytest"
+    assert all(hasattr(repo.orm, col) for col in ("id", "name", "age"))
 
     repo.add({"id": "a", "name": "Jack", "age": 500})
     assert list(repo) == [dict(id="a", name="Jack", age=500)]
@@ -145,8 +145,8 @@ def test_init_orm():
         name TEXT,
         age INTEGER
     )""", engine=engine)
-    repo = SQLRepo(model_orm=SQLItem, reflect_model=True, engine=engine)
-    assert repo.model_orm is SQLItem
+    repo = SQLRepo(orm=SQLItem, reflect_model=True, engine=engine)
+    assert repo.orm is SQLItem
     assert issubclass(repo.model, BaseModel)
 
     repo.add({"id": "a", "name": "Jack", "age": 500})
@@ -161,8 +161,8 @@ def test_init_model_and_orm():
         name TEXT,
         age INTEGER
     )""", engine=engine)
-    repo = SQLRepo(model=MyItem, model_orm=SQLItem, engine=engine)
-    assert repo.model_orm is SQLItem
+    repo = SQLRepo(model=MyItem, orm=SQLItem, engine=engine)
+    assert repo.orm is SQLItem
     assert issubclass(repo.model, BaseModel)
 
     repo.add({"id": "a", "name": "Jack", "age": 500})
@@ -313,7 +313,7 @@ def test_init_column(cls, nullable, sql_type):
     repo = SQLRepo(model=MyItem, engine=engine, table="mytable", if_missing="create", id_field="id")
     
     # Test column
-    column = repo.model_orm.__table__.columns['myfield']
+    column = repo.orm.__table__.columns['myfield']
     assert column.nullable is nullable
     assert isinstance(column.type, getattr(sqlalchemy, sql_type))
 

--- a/redbird/test/repo/test_sql.py
+++ b/redbird/test/repo/test_sql.py
@@ -317,11 +317,24 @@ def test_init_type_insert(cls, example_value):
 ])
 def test_init_column(cls, nullable, sql_type):
     pytest.importorskip("sqlalchemy")
-
-    class MyItem(BaseModel):
-        __id_field__ = "id"
-        id: str
-        myfield: cls
+    DEFAULT_ARG_TYPES = [
+        typing.Optional[str], 
+        typing.Union[str, None], 
+        typing.Union[None, str],
+        typing.Optional[Literal["yes", "no"]]
+        ]
+    if cls in DEFAULT_ARG_TYPES:
+        print(cls)
+        class MyItem(BaseModel):
+            __id_field__ = "id"
+            id: str
+            myfield: cls = None
+    else:
+        print(cls)
+        class MyItem(BaseModel):
+            __id_field__ = "id"
+            id: str
+            myfield: cls
     import sqlalchemy
     from sqlalchemy import create_engine
     engine = create_engine('sqlite://')

--- a/redbird/test/sql/test_create.py
+++ b/redbird/test/sql/test_create.py
@@ -77,7 +77,7 @@ def test_create_model(engine):
         name: str
         score: int = 999
         birth_date: date
-        color: Optional[str]
+        color: Optional[str] = None
 
     tbl = Table("mytable", bind=engine)
     tbl.create_from_model(MyModel)


### PR DESCRIPTION
Creating this as a work in progress/draft PR to get the ball rolling on the pydanticv2 migrations.
There's potentially a breaking change (changing the model_orm argument for SQLRepo to just orm). Using "model_" now clashes with a pydantic protected Namespace.
We might be able to get round this using a Field alias, but it would require some testing to see if it would still cause the clash.

Tests are still failing at this point but Memory Repo and SQLRepo are running in a basic test.

Will continue to work on this over the weekend hopefully.